### PR TITLE
Arch updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ packages=(
     stow 
     termite
     termite-terminfo
+    the_silver_searcher
     tree 
     tree 
     tmux

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ packages=(
     nerd-fonts-complete 
     nodejs 
     npm 
+    ntp
     nvm
     openssh 
     obs-studio

--- a/arch.sh
+++ b/arch.sh
@@ -23,6 +23,7 @@ packages=(
     nerd-fonts-complete 
     nodejs 
     npm 
+    ntp
     nvm
     openssh 
     obs-studio

--- a/arch.sh
+++ b/arch.sh
@@ -34,6 +34,7 @@ packages=(
     stow 
     termite
     termite-terminfo
+    the_silver_searcher
     tree 
     tree 
     tmux

--- a/arch/.xinitrc
+++ b/arch/.xinitrc
@@ -51,6 +51,9 @@ fi
 xrdb -merge ~/.Xresources &
 setxkbmap -option caps:escape &
 
+timedatectl set-timezone America/Chicago
+sudo ntpd -qg
+
 #twm &
 #xclock -geometry 50x50-1+1 &
 #xterm -geometry 80x50+494+51 &

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -13,7 +13,14 @@ set -s escape-time 0
 setw -g aggressive-resize on
 
 # setting color to xterm
-set -g default-terminal "screen-256color"
+#set -g default-terminal "screen-256color"
+
+# setting color to tmux as of tmux 2.1
+set -g default-terminal "xterm-256color"
+
+# ARCH: Vim style copying to clipboard using xclip for arch
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -i -sel clip > /dev/null"
+bind-key p run "xclip -o -sel clip | tmux load-buffer - ; tmux paste-buffer"
 
 # Unbind % and " as pane spliting to | and _
 bind | split-window -h

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -74,9 +74,10 @@ call plug#end()
 " enables sytax and plugins
 set number
 set relativenumber
-set tabstop=4
-set shiftwidth=4
-set softtabstop=4
+set tabstop=2
+set shiftwidth=2
+set softtabstop=2
+set encoding=UTF-8
 
 set expandtab
 syntax enable

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -278,6 +278,7 @@ let g:coc_global_extensions = [
   \ 'coc-python',
   \ 'coc-tsserver',
   \ 'coc-go',
+  \ 'coc-pairs',
   "\ 'coc-clangd',
   \ ]
 

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -10,13 +10,11 @@ alias @wp='~/workspaces'
 alias @dt='~/workspaces/dotfiles'
 alias @cp='~/workspaces/competativeProgramming'
 alias @af='~/workspaces/abasnfarah.github.io'
+alias @tmr='~/.tmux/resurrect/'
 
 ###############################################################################
 # Basic Aliases
 ###############################################################################
-
-# Tmux set up
-alias tmux="TERM=screen-256color tmux -2"
 
 alias v="vim"
 alias e="emacs"
@@ -52,10 +50,15 @@ alias wp=" cd ~/workspaces"
 alias p3="python3"
 
 # tmux aliases
+alias tmux="TERM=screen-256color tmux -2 -u"
 alias ts="tmux new -s"
 alias ta="tmux a -t"
 alias tls="tmux ls"
 alias tkill="tmux kill-server"
+function tmux_restore {
+    ln -sf ~/.tmux/resurrect/"$1.txt" ~/.tmux/resurrect/last
+    tmux
+}
 
 # C++ C Java Compiling and running
 alias jc="javac"

--- a/zsh/local.zsh
+++ b/zsh/local.zsh
@@ -19,8 +19,8 @@ neofetch
 # CASE_SENSITIVE="true"
 
 # Uncomment the following two lines to sync and set system time
-#timedatectl set-timezone America/Chicago
-#sudo ntpd -qg
+timedatectl set-timezone America/Chicago
+sudo ntpd -qg
 
 # Uncomment the follwing line to remove terminal beep sounds
 setopt nobeep

--- a/zsh/local.zsh
+++ b/zsh/local.zsh
@@ -19,8 +19,8 @@ neofetch
 # CASE_SENSITIVE="true"
 
 # Uncomment the following two lines to sync and set system time
-timedatectl set-timezone America/Chicago
-sudo ntpd -qg
+#timedatectl set-timezone America/Chicago
+#sudo ntpd -qg
 
 # Uncomment the follwing line to remove terminal beep sounds
 setopt nobeep

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -16,11 +16,11 @@ source ~/.plugins.zsh
 source ~/.screenlayout/two_monitor_layout.sh
 
 # FZF setup 
-[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh # mac
-#source /usr/share/fzf/key-bindings.zsh # arch
+#[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh # mac
+source /usr/share/fzf/key-bindings.zsh # arch
 #source /usr/share/fzf/completion.zsh # arch 
 # Adds hidden files to FZF 
-export FZF_DEFAULT_COMMAND='ag --hidden --ignore .git -l -g ""'
+#export FZF_DEFAULT_COMMAND='ag --hidden --ignore .git -l -g ""'
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 #source /usr/local/opt/powerlevel10k/powerlevel10k.zsh-theme # mac


### PR DESCRIPTION
## What is changed
1. A[dds The Silver Searcher for fzf](https://man.archlinux.org/man/ag.1.en)
2. [Adds Network Time Protocol Daemon](https://wiki.archlinux.org/title/Network_Time_Protocol_daemon)
3. [Installed Coc plugin for Vim called Coc-Pars](https://github.com/neoclide/coc-pairs)

## Why is it changed
1. The silver searcher provides the ng command which is the backend for the fzf command to do fuzzy file finding for vim and zsh.
2. The Network Time Protocol Daemon configures and resets the timectl and localectl to central time. This is due to a hardware discrepancy with time. The backend is the ntpd command. 
3. The coc-pairs extension for coc.nvim handles creating opening and closing brackets and parens. This speeds up development in vim. 

## Configurations affected
1. zsh and vim. [vim/vimrc ](https://github.com/abasnfarah/dotfiles/blob/main/vim/vimrc)and [zsh/zshrc](https://github.com/abasnfarah/dotfiles/blob/main/zsh/zshrc) are the files affected.
2. xorg configuration files pre windows manager bootup. [arch/.xinitrc ](https://github.com/abasnfarah/dotfiles/blob/main/arch/.xinitrc)is affected.
3. Updates vim configuration. [vim/vimrc ](https://github.com/abasnfarah/dotfiles/blob/main/vim/vimrc)is the file affected.